### PR TITLE
ci(haxe-ci): enable npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/haxe-ci.yml
+++ b/.github/workflows/haxe-ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: "npm"
       - name: Install dependencies
         run: npm ci
@@ -55,24 +55,30 @@ jobs:
       contents: write
       issues: write
       packages: write
+      # Required for npm OIDC trusted publishing (short-lived token exchange).
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           cache: "npm"
       - name: Install dependencies
         run: npm ci
+      # npm OIDC trusted publishing needs npm CLI >= 11.5.1; Node 22 ships npm 10.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: Install lix
         run: npm install --no-save lix
       - name: Set up Haxe via lix
         run: npx lix download
       - name: Run semantic release
-        env: # Or as an environment variable
+        env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HAXELIB_PASS: ${{ secrets.HAXELIB_PASS }}
+          # No NPM_TOKEN: npm publishing uses OIDC trusted publishing.
         run: |
           npm run build
           npx semantic-release


### PR DESCRIPTION
Enables npm OIDC trusted publishing in the shared \`haxe-ci.yml\` reusable workflow so consuming libraries can publish to npm without a long-lived \`NPM_TOKEN\`.

## Changes (semantic_release job)
- Add \`id-token: write\` permission — required for OIDC token exchange.
- Bump Node 16 → 22 — OIDC requires Node ≥ 22.14.
- Add \`npm install -g npm@latest\` — OIDC requires npm CLI ≥ 11.5.1 (Node 22 ships npm 10).
- unit_tests Node also bumped 16 → 22 (16 is EOL).

\`HAXELIB_PASS\` is unchanged; haxelib publishing is unaffected. No \`NPM_TOKEN\` is introduced.

## Required by consumers
- Caller workflow must also grant \`id-token: write\` (npm matches the **caller** filename for trusted publishing).
- A trusted publisher must be configured on npmjs.com (org-level recommended for new packages).
- The repo's \`semantic-release\`/\`@semantic-release/npm\` must be ≥ 25 / ≥ 13 for OIDC support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)